### PR TITLE
Widen width for bigger screens & add space for smaller screens

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -136,7 +136,8 @@ button.active {
 
 .bugs {
   margin: 0 auto 5em;
-  max-width: 40em;
+  padding: 0 1em;
+  max-width: 60em;
 }
 
 .bug {


### PR DESCRIPTION
Extended the width from 40em to 60em so fewer items wrap when there's enough space.
Put some padding around the main content so on small screens the tickets don't bump up against the edge of the screen.
