### PR TITLE
Styling bug number link colors

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -169,8 +169,14 @@ button.active {
 
 .bug-id {
   font-size: 0.75rem;
-  padding-left: .25rem;
+  padding-left: 1em;
   opacity: 0.75;
+}
+a.bug-id:link {
+  color:#0097CC;
+}
+a.bug-id:visited {
+  color:#707172;
 }
 
 .bug-summary {


### PR DESCRIPTION
I'm not sure that the visited color is doing anything. I can't double check from inside Firefox Dev Tools. I believe the syntax is right, but let's see.
