### PR TITLE
Adjusting line height of bug name

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -140,7 +140,7 @@ button.active {
 
 .bug {
   margin: 0.5em 0;
-  padding: 0.25em 1em 0.5em 1.75em;
+  padding: 0.25em 1em 0.75em 1.75em;
   box-shadow: 0px 1px 1px rgba(0,0,0,0.3);
   background-color: #fff;
   position: relative;
@@ -159,6 +159,10 @@ button.active {
   display: flex;
   justify-content: space-between;
   font-size: 0.75rem;
+}
+
+.bug-body {
+  line-height: 1.3;
 }
 
 .bugs li:last-child .bug {


### PR DESCRIPTION
The line height was too great for the main bug name text. Tightened it. And adjusted the padding to balance the bug box out again.
