### PR TITLE
removing opacity of 75% from bug links so they aren't so light

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -172,11 +172,12 @@ button.active {
 .bug-id {
   font-size: 0.75rem;
   padding-left: 1em;
-  opacity: 0.75;
 }
+
 a.bug-id:link {
   color:#0097CC;
 }
+
 a.bug-id:visited {
   color:#707172;
 }


### PR DESCRIPTION
Oooops, I meant to do this when I set the link color. Otherwise it's too light & could be hard for some people to read. Also, cleaning up CSS spacing.
